### PR TITLE
Beta

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==8.1.7
 Flask==3.0.3
 Flask-HTTPAuth==4.8.0
 flask-paginate==2024.4.12
-gunicorn==21.2.0
+gunicorn==22.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.3
 MarkupSafe==2.1.5


### PR DESCRIPTION
[chore(deps): bump gunicorn from 21.2.0 to 22.0.0](https://github.com/ash0ne/docker-pdf-server/commit/ed218ba6251b5d2c115561a33539d3032969bf00)